### PR TITLE
feat: implement UDP communication for SORACOM Unified Endpoint

### DIFF
--- a/examples/nodejs/src/udp.js
+++ b/examples/nodejs/src/udp.js
@@ -1,0 +1,18 @@
+const { Library } = require("ffi-napi");
+const { readFileSync } = require("fs");
+
+const soratun = Library("../../lib/shared/libsoratun", {
+  SendUDP: ["string", ["string","pointer","int"]]
+});
+
+const config = readFileSync(process.argv[2], "utf8");
+
+// Send UDP Packet for IoT Button
+const message = new Uint8Array(4);
+message[0] = 0x4d;
+message[1] = 1
+message[2] = 3
+message[3] = 0x4d + 1 + 3
+
+const response = soratun.SendUDP(config,message,4)
+console.log(response);

--- a/libsoratun.go
+++ b/libsoratun.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/0x6b/libsoratun/libsoratun"
 )
+import "unsafe"
 
 func main() {}
 
@@ -61,4 +62,42 @@ func Send(configJson, method, path, body *C.char) *C.char {
 	}
 
 	return C.CString(string(response))
+}
+
+// SendUDP is a function that uses SORACOM Arc configuration provided as a JSON string,
+// a port, and a payload to create and execute an UDP request to the SORACOM Unified Endpoint.
+// The function returns the response as a C language string, or nil if an error occurs.
+// Input parameters are expected to be C language strings.
+//
+// Parameters:
+//   - `configJson`: C string representation of SORACOM Arc configuration
+//   - `body`: body of the UDP request
+//   - `bodyLen`: length of the body
+//
+// Returns:
+//   - C string representation of the UDP response body, or nil if an error occurred
+//
+// Usage:
+//
+//	response := SendUDP(configJson, body, bodyLen)
+//
+//export SendUDP
+func SendUDP(configJson *C.char, body *C.char, bodyLen C.int) *C.char {
+	config, err := libsoratun.NewConfig([]byte(C.GoString(configJson)))
+	if err != nil {
+		return nil
+	}
+
+	c, err := libsoratun.NewUnifiedEndpointUDPClient(*config)
+	if err != nil {
+		return nil
+	}
+
+	bodyBytes := C.GoBytes(unsafe.Pointer(body), bodyLen)
+	res, err := c.DoUDPRequest(bodyBytes, 23080)
+	if err != nil {
+		return nil
+	}
+
+	return C.CString(res)
 }

--- a/libsoratun/client.go
+++ b/libsoratun/client.go
@@ -41,7 +41,7 @@ type Params struct {
 	Body string
 }
 
-// UnifiedEndpointUDPClient is an UDP client that can be used to communicate with SORACOM Unified Endpoint.
+// UnifiedEndpointUDPClient is a UDP client that can be used to communicate with SORACOM Unified Endpoint.
 type UnifiedEndpointUDPClient struct {
 	dialcontext func(ctx context.Context, network string, addr string) (net.Conn, error)
 	logger      *device.Logger

--- a/libsoratun/client.go
+++ b/libsoratun/client.go
@@ -11,6 +11,10 @@ import (
 
 	"golang.zx2c4.com/wireguard/device"
 )
+import (
+	"context"
+	"net"
+)
 
 var Revision = "dev"
 
@@ -35,6 +39,12 @@ type Params struct {
 	Path string
 	// Body is a body of the request.
 	Body string
+}
+
+// UnifiedEndpointUDPClient is an UDP client that can be used to communicate with SORACOM Unified Endpoint.
+type UnifiedEndpointUDPClient struct {
+	dialcontext func(ctx context.Context, network string, addr string) (net.Conn, error)
+	logger      *device.Logger
 }
 
 // NewUnifiedEndpointHTTPClient creates a new HTTP client specific for the SORACOM Unified Endpoint.
@@ -71,6 +81,37 @@ func NewUnifiedEndpointHTTPClient(config Config) (*UnifiedEndpointHTTPClient, er
 		endpoint: endpoint,
 		headers:  []string{ua},
 		logger:   logger,
+	}, nil
+}
+
+// NewUnifiedEndpointUDPClient creates a new UDP client specific for the SORACOM Unified Endpoint.
+//
+// Args:
+// - `config`: A Config object containing the configuration for the SORACOM Arc connection.
+//
+// Returns:
+// - `*UnifiedEndpointUDPClient`: A pointer to the created UnifiedEndpointUDPClient and an error object. If there's any error occurred during setting up the tunnel connection or parsing the endpoint URL, the error will be returned.
+//
+// The created client uses the udp.
+func NewUnifiedEndpointUDPClient(config Config) (*UnifiedEndpointUDPClient, error) {
+	logger := device.NewLogger(config.LogLevel, "(libsoratun/client) ") // lazily use device.Logger for logging
+	t, err := newTunnel(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, err := url.Parse(fmt.Sprintf("http://%s:%d", UnifiedEndpointHostname, UnifiedEndpointPort))
+	if err != nil {
+		return nil, err
+	}
+
+	ua := fmt.Sprintf("User-Agent: libsoratun/%s", Revision)
+	logger.Verbosef("Soracom Unified Endpoint URL: %s", endpoint)
+	logger.Verbosef("%s", ua)
+
+	return &UnifiedEndpointUDPClient{
+		dialcontext: t.DialContext,
+		logger:      logger,
 	}, nil
 }
 
@@ -154,4 +195,36 @@ func (c *UnifiedEndpointHTTPClient) DoRequest(req *http.Request) (*http.Response
 	}
 
 	return res, nil
+}
+
+// DoUDPRequest sends an UDP request and returns the response.
+//
+// Args:
+// - `Body`: A request body
+// - `port`: A string representing the address to send the request to.
+//
+// Returns:
+// - `string`: A response string, and an error object.
+func (c *UnifiedEndpointUDPClient) DoUDPRequest(body []byte, port int16) (string, error) {
+	addr := fmt.Sprintf("%s:%d", UnifiedEndpointHostname, port)
+	conn, err := c.dialcontext(context.Background(), "udp", addr)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	len, err := conn.Write([]byte(body))
+	if err != nil {
+		c.logger.Errorf("Failed to Write packet", err)
+		return "", err
+	}
+	c.logger.Verbosef("UDP sent %d bytes", len)
+
+	res := make([]byte, 1024)
+
+	len, err = conn.Read(res)
+	if err != nil {
+		return "", err
+	}
+	c.logger.Verbosef("UDP received %d bytes", len)
+	return string(res), nil
 }


### PR DESCRIPTION
Please review in Japanese.
close #1 

This pull request introduces a new feature to enable UDP communication with the SORACOM Unified Endpoint using a newly implemented UDP client. The key changes include adding a `SendUDP` function in the Go library, implementing a `UnifiedEndpointUDPClient` for handling UDP requests, and integrating this functionality into the Node.js example. Below are the most important changes grouped by theme:

### Node.js Integration:
* Added a Node.js example (`examples/nodejs/src/udp.js`) demonstrating the use of the new `SendUDP` function to send UDP packets to the SORACOM Unified Endpoint. This includes loading the shared library and sending a sample IoT button message.

### Go Library Enhancements:
* Introduced the `SendUDP` function in `libsoratun.go` to handle UDP requests. This function takes a JSON configuration, a payload, and its length as input, and returns the response as a C string.
* Added a new `UnifiedEndpointUDPClient` type in `libsoratun/client.go` to facilitate UDP communication, including methods for creating the client (`NewUnifiedEndpointUDPClient`) and sending UDP requests (`DoUDPRequest`). [[1]](diffhunk://#diff-3ab77b934c51451360f82a8e663f78f948ee3844738237733deeca334be7704fR44-R49) [[2]](diffhunk://#diff-3ab77b934c51451360f82a8e663f78f948ee3844738237733deeca334be7704fR87-R117) [[3]](diffhunk://#diff-3ab77b934c51451360f82a8e663f78f948ee3844738237733deeca334be7704fR199-R230)

### Auxiliary Updates:
* Added necessary imports (`unsafe`, `context`, `net`) in the Go files to support the new UDP functionality. [[1]](diffhunk://#diff-8e545f5b50b353a531b0f44a15e41e8e49673911ac3df90ae53883c74eb8b03aR10) [[2]](diffhunk://#diff-3ab77b934c51451360f82a8e663f78f948ee3844738237733deeca334be7704fR14-R17)