### PR TITLE
feat: use ffi-rs instead of ffi-napi

### DIFF
--- a/examples/nodejs/package-lock.json
+++ b/examples/nodejs/package-lock.json
@@ -9,104 +9,203 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "ffi-napi": "^4.0.3"
+        "node-ffi-rs": "^1.2.10"
       }
     },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
+    "node_modules/@yuuang/ffi-rs-android-arm64": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-android-arm64/-/ffi-rs-android-arm64-1.2.10.tgz",
+      "integrity": "sha512-jkYl/qJnhlY3sjhkDnerLfCqVpqrmKUruOy2WbYS9Lu8sRIDBEmuWx5JYSMtB7o9dLE4JY+8YhSPulhBTYbANw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">= 12"
       }
     },
-    "node_modules/ffi-napi": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
-      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-uv-event-loop-napi-h": "^1.0.5",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1",
-        "ref-napi": "^2.0.1 || ^3.0.2",
-        "ref-struct-di": "^1.1.0"
-      },
+    "node_modules/@yuuang/ffi-rs-darwin-arm64": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.2.10.tgz",
+      "integrity": "sha512-iezEXSSLtQvcV8r9rgmCPjfzff5PUvIxKGlgtdj7Ue+FAcM89pzW0VLA0SriamGrWVG+P1DnR0796m7/76Njww==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">=10"
+        "node": ">= 12"
       }
     },
-    "node_modules/get-symbol-from-current-process-h": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
-      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
-    },
-    "node_modules/get-uv-event-loop-napi-h": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
-      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
-      "dependencies": {
-        "get-symbol-from-current-process-h": "^1.0.1"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/ref-napi": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
-      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.1"
-      },
+    "node_modules/@yuuang/ffi-rs-darwin-x64": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.2.10.tgz",
+      "integrity": "sha512-Hvqm7kFXBPDqEK88Jsp8UXKDQpXeQqNSdkX3YepIooZ/d/bqmV8NjpdNRG0YW8ATpi8Dl1DbFdmO5tLgQcnUXg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">= 10.0"
+        "node": ">= 12"
       }
     },
-    "node_modules/ref-struct-di": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
-      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
-      "dependencies": {
-        "debug": "^3.1.0"
+    "node_modules/@yuuang/ffi-rs-linux-arm-gnueabihf": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm-gnueabihf/-/ffi-rs-linux-arm-gnueabihf-1.2.10.tgz",
+      "integrity": "sha512-rh8QyQZv/7M13BXIrQeZ1IS32U5R7XUM6fuNalVZhNKw86AsioNWS54S6lwRH+2qtIfMNslw1/KtlchbeOBJSw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
       }
     },
-    "node_modules/ref-struct-di/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
+    "node_modules/@yuuang/ffi-rs-linux-arm64-gnu": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.2.10.tgz",
+      "integrity": "sha512-0KNATJlYyCcdklOLsii/bq0JtMBGCdbDt9fAXmQ0GzZkuJB9eB0QhdwuVSwOvjoY6do1hIqv8r7GdoIBp3ajkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-arm64-musl": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.2.10.tgz",
+      "integrity": "sha512-g8vMwGStVNN6/gtMtxw8DeZWhxK5Z0MuQqIRRFF/FVQFTLhrHRmxJ1NfXlRWgHJzECaWlTNwrnFPB7j48O8FcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-x64-gnu": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.2.10.tgz",
+      "integrity": "sha512-wNGpsVhphbQCZJo/4Bkgjq0qyMv55rTXy+117hC2GTGpYDmhcV2tVfEugfDiQr64QUkF4I7NRSU40xtuYZ6ORg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-x64-musl": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.2.10.tgz",
+      "integrity": "sha512-kpFQS/us9QWstdyrKKdmFfRe95iYBdT0/0ct+Rqj3sWZgKhy45kheZbfOGVGKC6IKd0ZtSmCeLf4vvFXBX8nmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-arm64-msvc": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.2.10.tgz",
+      "integrity": "sha512-8wPV1fNTmX0Ct95NSd7PJyqhd+b1zthwIGIZITTSK6wEQufCwm3UduhcrlZr9FamnBnskwL19nWpM4foQFcPQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-ia32-msvc": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.2.10.tgz",
+      "integrity": "sha512-3G2vYAEPpyEErkpr9PGuULfm5sbtvsn3RFt+5nh/RB+kTG/HP8mai+gNHQIE6I//udZE8w6RhYXuZMB2Ri2+zw==",
+      "cpu": [
+        "x64",
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-x64-msvc": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.2.10.tgz",
+      "integrity": "sha512-hAv+RHe1WMB5gk4QDRC8/T9Tw9YiE6DqNNnw+Snl2xbDJ2xyr8B7cHit0OgRX11G9f6l8cjOtzSz+qGncFF5tA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/node-ffi-rs": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/node-ffi-rs/-/node-ffi-rs-1.2.10.tgz",
+      "integrity": "sha512-13lC97isXygJPYNHFTqOLmE4R5/9WhnYoVp28gucbszdQNfNPEZ1242W8I7uYIcFR1+nyewItvM1aL6zr+zBhA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@yuuang/ffi-rs-android-arm64": "1.2.10",
+        "@yuuang/ffi-rs-darwin-arm64": "1.2.10",
+        "@yuuang/ffi-rs-darwin-x64": "1.2.10",
+        "@yuuang/ffi-rs-linux-arm-gnueabihf": "1.2.10",
+        "@yuuang/ffi-rs-linux-arm64-gnu": "1.2.10",
+        "@yuuang/ffi-rs-linux-arm64-musl": "1.2.10",
+        "@yuuang/ffi-rs-linux-x64-gnu": "1.2.10",
+        "@yuuang/ffi-rs-linux-x64-musl": "1.2.10",
+        "@yuuang/ffi-rs-win32-arm64-msvc": "1.2.10",
+        "@yuuang/ffi-rs-win32-ia32-msvc": "1.2.10",
+        "@yuuang/ffi-rs-win32-x64-msvc": "1.2.10"
       }
     }
   }

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -10,6 +10,6 @@
   "author": "kaoru <k@warpnine.io>",
   "license": "MIT",
   "dependencies": {
-    "ffi-napi": "^4.0.3"
+    "node-ffi-rs": "^1.2.10"
   }
 }

--- a/examples/nodejs/src/index.js
+++ b/examples/nodejs/src/index.js
@@ -1,9 +1,17 @@
-const { Library } = require("ffi-napi");
+const { open, load, DataType, Result, unwrapErr } = require('node-ffi-rs');
 const { readFileSync } = require("fs");
-
-const soratun = Library("../../lib/shared/libsoratun", {
-  Send: ["string", ["string", "string", "string", "string"]],
-});
+const { platform } = require("os");
+open({
+  library: 'libsoratun',
+  path: '../../lib/shared/libsoratun' + (platform() === "win32" ? ".dll" : ".so")
+})
 
 const config = readFileSync(process.argv[2], "utf8");
-soratun.Send(config, "POST", "/", process.argv[3]);
+const response = load({
+  library: 'libsoratun',
+  funcName: 'Send',
+  retType: DataType.String,
+  paramsType: [DataType.String, DataType.String, DataType.String, DataType.String],
+  paramsValue: [config, "POST", "/", process.argv[3]]
+});
+console.log(response);

--- a/examples/nodejs/src/index.js
+++ b/examples/nodejs/src/index.js
@@ -1,17 +1,22 @@
 const { open, load, DataType, Result, unwrapErr } = require('node-ffi-rs');
 const { readFileSync } = require("fs");
 const { platform } = require("os");
-open({
-  library: 'libsoratun',
-  path: '../../lib/shared/libsoratun' + (platform() === "win32" ? ".dll" : ".so")
-})
 
-const config = readFileSync(process.argv[2], "utf8");
-const response = load({
-  library: 'libsoratun',
-  funcName: 'Send',
-  retType: DataType.String,
-  paramsType: [DataType.String, DataType.String, DataType.String, DataType.String],
-  paramsValue: [config, "POST", "/", process.argv[3]]
-});
-console.log(response);
+try {
+  open({
+    library: 'libsoratun',
+    path: '../../lib/shared/libsoratun' + (platform() === "win32" ? ".dll" : ".so")
+  })
+
+  const config = readFileSync(process.argv[2], "utf8");
+  const response = load({
+    library: 'libsoratun',
+    funcName: 'Send',
+    retType: DataType.String,
+    paramsType: [DataType.String, DataType.String, DataType.String, DataType.String],
+    paramsValue: [config, "POST", "/", process.argv[3]]
+  });
+  console.log(response);
+} catch (error) {
+  console.error('Error:', error);
+}

--- a/examples/nodejs/src/udp.js
+++ b/examples/nodejs/src/udp.js
@@ -1,11 +1,5 @@
 const { open, load, DataType, Result, unwrapErr } = require('node-ffi-rs');
-
-const { Library } = require("ffi-napi");
 const { readFileSync } = require("fs");
-
-const soratun = Library("../../lib/shared/libsoratun", {
-  SendUDP: ["string", ["string","pointer","int"]]
-});
 
 const config = readFileSync(process.argv[2], "utf8");
 
@@ -18,8 +12,8 @@ message[3] = 0x4d + 1 + 3
 
 try {
   open({
-    library: 'libsoratun', // key
-    path: '../../lib/shared/libsoratun.dll' // path
+    library: 'libsoratun',
+    path: '../../lib/shared/libsoratun' + (platform() === "win32" ? ".dll" : ".so")
   })
 
   const response = load({

--- a/examples/nodejs/src/udp.js
+++ b/examples/nodejs/src/udp.js
@@ -1,3 +1,5 @@
+const { open, load, DataType, Result, unwrapErr } = require('node-ffi-rs');
+
 const { Library } = require("ffi-napi");
 const { readFileSync } = require("fs");
 
@@ -14,5 +16,20 @@ message[1] = 1
 message[2] = 3
 message[3] = 0x4d + 1 + 3
 
-const response = soratun.SendUDP(config,message,4)
-console.log(response);
+try {
+  open({
+    library: 'libsoratun', // key
+    path: '../../lib/shared/libsoratun.dll' // path
+  })
+
+  const response = load({
+    library: 'libsoratun',
+    funcName: 'SendUDP',
+    retType: DataType.String,
+    paramsType: [DataType.String, DataType.U8Array, DataType.I64],
+    paramsValue: [config, message, message.length]
+  });
+  console.log(response);
+} catch (error) {
+  console.error('Error:', error);
+}

--- a/examples/nodejs/src/udp.js
+++ b/examples/nodejs/src/udp.js
@@ -1,5 +1,6 @@
 const { open, load, DataType, Result, unwrapErr } = require('node-ffi-rs');
 const { readFileSync } = require("fs");
+const { platform } = require("os");
 
 const config = readFileSync(process.argv[2], "utf8");
 

--- a/libsoratun.go
+++ b/libsoratun.go
@@ -85,18 +85,18 @@ func Send(configJson, method, path, body *C.char) *C.char {
 func SendUDP(configJson *C.char, body *C.char, bodyLen C.int) *C.char {
 	config, err := libsoratun.NewConfig([]byte(C.GoString(configJson)))
 	if err != nil {
-		return nil
+		return C.CString("Error on NewConfig")
 	}
 
 	c, err := libsoratun.NewUnifiedEndpointUDPClient(*config)
 	if err != nil {
-		return nil
+		return C.CString("Error on NewUnifiedEndpointUDPClient")
 	}
 
 	bodyBytes := C.GoBytes(unsafe.Pointer(body), bodyLen)
 	res, err := c.DoUDPRequest(bodyBytes, 23080)
 	if err != nil {
-		return nil
+		return C.CString("Error on DoUDPRequest")
 	}
 
 	return C.CString(res)

--- a/libsoratun.go
+++ b/libsoratun.go
@@ -85,17 +85,20 @@ func Send(configJson, method, path, body *C.char) *C.char {
 func SendUDP(configJson *C.char, body *C.char, bodyLen C.int) *C.char {
 	config, err := libsoratun.NewConfig([]byte(C.GoString(configJson)))
 	if err != nil {
+		fmt.Printf("Error on NewConfig: %v\n", err)
 		return C.CString("Error on NewConfig")
 	}
 
 	c, err := libsoratun.NewUnifiedEndpointUDPClient(*config)
 	if err != nil {
+		fmt.Printf("Error on NewUnifiedEndpointUDPClient: %v\n", err)
 		return C.CString("Error on NewUnifiedEndpointUDPClient")
 	}
 
 	bodyBytes := C.GoBytes(unsafe.Pointer(body), bodyLen)
 	res, err := c.DoUDPRequest(bodyBytes, 23080)
 	if err != nil {
+		fmt.Printf("Error on DoUDPRequest: %v\n", err)
 		return C.CString("Error on DoUDPRequest")
 	}
 


### PR DESCRIPTION
Please review in Japanese.

This pull request introduces significant changes to the Node.js example project, focusing on replacing the `ffi-napi` library with `node-ffi-rs` for improved functionality and error handling. It also updates the Go backend function to provide more descriptive error messages. Below is a summary of the most important changes:

### Library Migration and Dependency Updates

* Replaced `ffi-napi` with `node-ffi-rs` in `package.json` and `package-lock.json`, including the addition of platform-specific optional dependencies for `node-ffi-rs`. This change ensures compatibility across multiple operating systems and architectures. [[1]](diffhunk://#diff-57edb97c83030cc172b4d65fbf460fd56fade5fb4d7eedad9741f48329b9ed29L13-R13) [[2]](diffhunk://#diff-8cf92a1ebf0dc4cc9cd003f430b075b4c378299bac134577fdf01acecfe44e5eL12-R208)

### Code Updates for `node-ffi-rs`

* Updated `examples/nodejs/src/udp.js` to use `node-ffi-rs` functions such as `open` and `load` for dynamic library loading and function invocation. This includes a new `try-catch` block for error handling during library operations. [[1]](diffhunk://#diff-f14a95465d2c96ce80d214f44d4a01ff4d0c0a7a4b61f80fdc92d539a293087aR1-R2) [[2]](diffhunk://#diff-f14a95465d2c96ce80d214f44d4a01ff4d0c0a7a4b61f80fdc92d539a293087aL17-R35)

### Improved Error Handling in Go Backend

* Modified the `SendUDP` function in `libsoratun.go` to return descriptive error messages as C strings instead of `nil` when errors occur during configuration, client creation, or UDP request execution.