### PR TITLE
fix: correct conditional block for Windows shared library build in Ma…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ libs: $(LIB_SHARED) $(LIB_ARCHIVE) ## Build libraries
 $(LIB_SHARED): $(SRC) go.mod ## Build shared library
 	go build -buildmode=c-shared $(LDFLAGS) -o $(LIB_DIR)/shared/lib$(NAME).so $(LIB_ENTRY)
 	go build -buildmode=c-shared $(LDFLAGS) -o $(LIB_DIR)/shared/lib$(NAME).dylib $(LIB_ENTRY)
+ifeq ($(shell uname -s),Linux)
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CXX=x86_64-w64-mingw32-g++ CC=x86_64-w64-mingw32-gcc go build -buildmode=c-shared $(LDFLAGS) -o $(LIB_DIR)/shared/lib$(NAME).dll $(LIB_ENTRY)
+endif
 
 $(LIB_ARCHIVE): $(SRC) go.mod ## Build archive library
 	go build -buildmode=c-archive $(LDFLAGS) -o $(LIB_DIR)/archive/lib$(NAME).a $(LIB_ENTRY)


### PR DESCRIPTION
This pull request updates the `Makefile` to conditionally build a Windows `.dll` shared library only when the build system is running Linux. This change ensures compatibility and avoids unnecessary build attempts on non-Linux systems.

Build system compatibility:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R28-R30): Wrapped the command to build the Windows `.dll` shared library with a conditional `ifeq` statement to check if the system is Linux (`uname -s`). This ensures the `.dll` is only built on Linux systems.…kefile